### PR TITLE
remove information on Guido

### DIFF
--- a/info/task_description.html
+++ b/info/task_description.html
@@ -53,9 +53,3 @@ checkio(1022) == 9
     0 &lt; number &le; 2<sup>32</sup>
 
 </p>
-<div class="facts for_info_only">
-    <p>
-        Guido van Rossum, the author of Python, is one of our most famous player. He is writing some really wonderful
-        code reviews for our player solutions.
-    </p>
-</div>


### PR DESCRIPTION
This paragraph should either have a link to Guido's profile or - seeing that he has been inactive on checkio for 5 years - be removed IMHO.